### PR TITLE
[WIP] herokuへのDeploy script

### DIFF
--- a/.circleci/setup-heroku.sh
+++ b/.circleci/setup-heroku.sh
@@ -1,0 +1,16 @@
+  #!/bin/bash
+  wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
+  mkdir -p /usr/local/lib /usr/local/bin
+  tar -xvzf heroku-linux-amd64.tar.gz -C /usr/local/lib
+  ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
+
+  cat > ~/.netrc << EOF
+  machine api.heroku.com
+    login $HEROKU_LOGIN
+    password $HEROKU_API_KEY
+  EOF
+
+  cat >> ~/.ssh/config << EOF
+  VerifyHostKeyDNS yes
+  StrictHostKeyChecking no
+  EOF


### PR DESCRIPTION
# why
Circieci2.0のCIが終わった後に成功したら自動でDeployする運用が楽だから

# how
- circleci2.0でまだherokuへのdeploy対応ができてないので、scriptを使ってやる。参考は[ここ](https://circleci.com/docs/2.0/deployment_integrations/#heroku)